### PR TITLE
Add comment about gevent option not supported

### DIFF
--- a/sample-demo-flask-app/README.md
+++ b/sample-demo-flask-app/README.md
@@ -64,11 +64,13 @@ Start the service using the gunicorn configuration.
 gunicorn "flaskr:create_app()" -c gunicorn_conf.py --log-level DEBUG --workers=5
 ```
 
+Note that the agent currently does NOT work with -k option for gevent workers.
+
 ### Generate traffic
 
 Generate traffic by running the following script that will make thousands of requests to the local server started at `http://127.0.0.1:8000`.
 ```bash
-./generate_traffic.sh
+./generate-traffic.sh
 ```
 
 ## How to see the results


### PR DESCRIPTION
Following latest test we discovered that the agent was not collecting data when -k gevent option was used for gevent workers. This is a limitation for now, we have not investigated further into the issue and have no solution to propose yet.
Adding a comment in this readme to notify customers about it.

Also fixed a typo for generate-traffic.sh script name.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
